### PR TITLE
Servant: ServerError

### DIFF
--- a/servant/myfile.txt
+++ b/servant/myfile.txt
@@ -1,1 +1,0 @@
-My file content

--- a/servant/servant-cookbook.cabal
+++ b/servant/servant-cookbook.cabal
@@ -16,6 +16,7 @@ library
     build-depends:
         aeson >=1.4 && <1.5,
         base >=4.13 && <4.14,
+        directory >=1.3 && <1.4,
         servant-server >=0.17 && <0.18,
         warp >=3.3 && <3.4
 

--- a/servant/src/Cookbooks/Servant.hs
+++ b/servant/src/Cookbooks/Servant.hs
@@ -14,7 +14,8 @@ import Data.Aeson (ToJSON)
 import Data.Proxy (Proxy (Proxy))
 import GHC.Generics (Generic)
 import Network.Wai.Handler.Warp (run)
-import Servant ((:>), Application, Get, JSON, Server, serve)
+import Servant ((:>), Application, Get, JSON, Server, err404, errBody, serve, throwError)
+import System.Directory (doesFileExist)
 
 type IOAPI1 = "myfile.txt" :> Get '[JSON] FileContent
 
@@ -25,18 +26,22 @@ newtype FileContent
 
 instance ToJSON FileContent
 
-server5 :: Server IOAPI1
-server5 = do
-  filecontent <- liftIO (readFile "myfile.txt")
-  pure (FileContent filecontent)
+server6 :: Server IOAPI1
+server6 = do
+  exists <- liftIO (doesFileExist "myfile.txt")
+  if exists
+    then FileContent <$> liftIO (readFile "myfile.txt")
+    else throwError custom404Err
+  where
+    custom404Err = err404 {errBody = "myfile.txt just isn't there."}
 
 ioAPI :: Proxy IOAPI1
 ioAPI = Proxy
 
-app5 :: Application
-app5 = serve ioAPI server5
+app6 :: Application
+app6 = serve ioAPI server6
 
 runServer :: IO ()
 runServer = do
   putStrLn "Starting server"
-  run 8081 app5
+  run 8081 app6


### PR DESCRIPTION
Failing, through `ServerError`

https://docs.servant.dev/en/stable/tutorial/Server.html#failing-through-servererror

Example:
```
$ echo foo > myfile.txt
$ curl -v localhost:8081/myfile.txt
...
< HTTP/1.1 200 OK
< Transfer-Encoding: chunked
< Date: Sat, 04 Jul 2020 03:14:38 GMT
< Server: Warp/3.3.13
< Content-Type: application/json;charset=utf-8
<
* Connection #0 to host localhost left intact
{"content":"foo\n"}
```
```
$ rm myfile.txt
$ curl -v localhost:8081/myfile.txt
...
< HTTP/1.1 404 Not Found
< Transfer-Encoding: chunked
< Date: Sat, 04 Jul 2020 03:14:47 GMT
< Server: Warp/3.3.13
<
* Connection #0 to host localhost left intact
myfile.txt just isn't there.
```