### PR TITLE
Streaming endpoints

### DIFF
--- a/servant/servant-cookbook.cabal
+++ b/servant/servant-cookbook.cabal
@@ -14,8 +14,11 @@ library
     hs-source-dirs:   src
     default-language: Haskell2010
     build-depends:
+        aeson >=1.4 && <1.5,
         base >=4.13 && <4.14,
+        servant >=0.17 && <0.18,
         servant-server >=0.17 && <0.18,
+        time >=1.9 && <1.10,
         warp >=3.3 && <3.4
 
 executable servant-cookbook


### PR DESCRIPTION
https://docs.servant.dev/en/stable/tutorial/Server.html#streaming-endpoints

Example:
```
$ curl localhost:8081/userStream
{"email":"isaac@newton.co.uk","registration_date":"1683-03-01","age":372,"name":"Isaac Newton"}
{"email":"ae@mc2.org","registration_date":"1905-12-01","age":136,"name":"Albert Einstein"}
{"email":"ae@mc2.org","registration_date":"1905-12-01","age":136,"name":"Albert Einstein"}
```